### PR TITLE
Workaround for Android

### DIFF
--- a/lib/Stream/Buffered/File.pm
+++ b/lib/Stream/Buffered/File.pm
@@ -3,11 +3,13 @@ use strict;
 use warnings;
 use base 'Stream::Buffered';
 
+use File::Spec;
 use IO::File;
 
 sub new {
     my $class = shift;
 
+    local $ENV{TMPDIR} = File::Spec->tmpdir;
     my $fh = IO::File->new_tmpfile;
     $fh->binmode;
 


### PR DESCRIPTION
Hi,

On Android with [Termux](https://termux.com/) and Perl 5.24.0 this module is broken because `IO::File->new_tmpfile` works incorrectly and returns `undef`. Fortunately, easy fix is just to set `TMPDIR` environment variable based on `File::Spec->tmpdir`.
