### PR TITLE
Signal success on buffer writing with PerlIO

### DIFF
--- a/lib/Stream/Buffered/Auto.pm
+++ b/lib/Stream/Buffered/Auto.pm
@@ -13,14 +13,15 @@ sub new {
 
 sub print {
     my $self = shift;
-    $self->{_buffer}->print(@_);
+    my $res = $self->{_buffer}->print(@_);
 
     if ($self->{_max} && $self->{_buffer}->size > $self->{_max}) {
         my $buf = $self->{_buffer}->{buffer};
         $self->{_buffer} = Stream::Buffered->create('File'),
-        $self->{_buffer}->print($buf);
+        $res = $self->{_buffer}->print($buf);
         delete $self->{_max};
     }
+    return $res;
 }
 
 sub size {

--- a/lib/Stream/Buffered/PerlIO.pm
+++ b/lib/Stream/Buffered/PerlIO.pm
@@ -11,6 +11,7 @@ sub new {
 sub print {
     my $self = shift;
     $self->{buffer} .= "@_";
+    return 1;
 }
 
 sub size {

--- a/t/write-zero.t
+++ b/t/write-zero.t
@@ -1,0 +1,48 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+use Stream::Buffered;
+
+{
+    local $Stream::Buffered::MaxMemoryBufferSize = -1;
+    my $b = Stream::Buffered->new;
+    ok $b->print(0), "Writing returns true with PerlIO";
+    _is_zero($b);
+}
+
+{
+    local $Stream::Buffered::MaxMemoryBufferSize = 0;
+    my $b = Stream::Buffered->new;
+    ok $b->print(0), "Writing returns true with temp file";
+    _is_zero($b);
+}
+
+{
+    # auto
+    my $b = Stream::Buffered->new;
+    ok $b->print(0), "Writing returns true with auto";
+    _is_zero($b);
+}
+
+{
+    # auto with max
+    local $Stream::Buffered::MaxMemoryBufferSize = 3;
+    my $b = Stream::Buffered->new;
+    for (1..4) {
+        ok $b->print(0), "Writing returns true with auto";
+    }
+    my $fh = $b->rewind;
+    is do { local $/; <$fh> }, '0' x 4, "Buffer content OK";
+}
+
+
+
+sub _is_zero {
+    my $b = shift;
+    my $fh = $b->rewind;
+    is do { local $/; <$fh> }, '0', "Buffer content is zero";
+}
+
+done_testing;


### PR DESCRIPTION
As explained in GH#4, Catalyst is using the return value of the ->print
call. This fails if the chunk is a falsy string.

This patch makes the return value consistent with the File backend.

Address https://github.com/plack/Stream-Buffered/issues/4